### PR TITLE
Implement search paths and XDG config

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,22 @@ in any of these directories.  In this case, we simply keep the default values of
 parameters.
 
 
+### Using XDG Base Directory Specification
+
+If your application follows the [XDG Base Directory
+Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+you can use ``load_xdg_config()`` (currently not supported on Windows!):
+
+```python
+wconf.load_xdg_config("myapp/config.toml")
+```
+Will search for the file in the directories specified in the environment variables
+`XDG_CONFIG_HOME` and `XDG_CONFIG_DIRS` (defaulting to `~/.config`).
+
+Like for `load_file()` there is an argument `fail_if_not_found` but here it defaults to
+False as providing a config in `XDG_CONFIG_HOME` is typically optional.
+
+
 ### Supported File Types
 
 Supported file types are JSON, YAML and TOML.  Support for custom file types can be
@@ -184,4 +200,3 @@ Missing Features
   `OmegaConf.set_struct`).
 - Option to load the config schema from a file.
 - Use custom errors, e.g. in case of unsupported file formats.
-- Find config file based on [XDG specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ schema = {"sec1": {"foo": 42, "bar": 13}, "sec2": {"bla": ""}}
 wconf = variconf.WConf(schema)
 config = (
     wconf.load_file("~/global_config.toml")
-    .load_file("./local_config.yml")
+    .load_file("./local_config.yml", fail_if_not_found=False)
     .load_dotlist(sys.argv[1:])  # easily allow overwriting parameters via
                                  # command-line arguments
     .get()  # return the final config object
@@ -106,11 +106,14 @@ Assuming an application where the config file can be located in one of several p
 wconf.load_file(
     "config.yml",
     search_paths=[os.expanduser("~"), os.expanduser("~/.config"), "/etc/myapp"],
+    fail_if_not_found=False,
 )
 ```
 This will search for a file "config.yml" in the listed directories (in the given order)
-and use the first match.  If none of the directories contains the file, `load_file()`
-will return without loading anything, thus keeping the default values.
+and use the first match.
+By setting `fail_if_not_found=False`, we specify that it's okay if the file is not found
+in any of these directories.  In this case, we simply keep the default values of all
+parameters.
 
 
 ### Supported File Types

--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ config = (
 )
 ```
 
+
+### Search File
+
+Assuming an application where the config file can be located in one of several places
+(e.g. `~`, `~/.config` or `/etc/myapp`).  This situation is supported by the optional
+`search_paths` argument of `load_file()`:
+
+```python
+wconf.load_file(
+    "config.yml",
+    search_paths=[os.expanduser("~"), os.expanduser("~/.config"), "/etc/myapp"],
+)
+```
+This will search for a file "config.yml" in the listed directories (in the given order)
+and use the first match.  If none of the directories contains the file, `load_file()`
+will return without loading anything, thus keeping the default values.
+
+
 ### Supported File Types
 
 Supported file types are JSON, YAML and TOML.  Support for custom file types can be
@@ -163,5 +181,4 @@ Missing Features
   `OmegaConf.set_struct`).
 - Option to load the config schema from a file.
 - Use custom errors, e.g. in case of unsupported file formats.
-- Find config file in a list of possible locations.
 - Find config file based on [XDG specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

--- a/test/data/conf2.json
+++ b/test/data/conf2.json
@@ -1,0 +1,12 @@
+{
+    "type": "json",
+    "foobar": {
+        "foo": 123,
+        "bar": 456,
+        "nested": {
+            "one": 99,
+            "two": 91,
+            "three": 93
+        }
+    }
+}

--- a/variconf/wconf.py
+++ b/variconf/wconf.py
@@ -149,7 +149,11 @@ class WConf:
 
         return self
 
-    def load_file(self, file: _PathLike) -> WConf:
+    def load_file(
+        self,
+        file: _PathLike,
+        search_paths: typing.Optional[typing.Sequence[_PathLike]] = None,
+    ) -> WConf:
         """Load configuration from the specified file.
 
         The format of the file is derived from the filename extension.
@@ -157,12 +161,36 @@ class WConf:
         loaders for other formats can be added with :meth:`add_file_loader`.
 
         Args:
-            file: A file in one of the supported formats.
+            file:  A file in one of the supported formats.
+            search_paths:  List of directories.  If set, search these directories for a
+                file with the name specified in ``file`` and loads the first file that
+                is found.  If no matching file is found, do not load anything (i.e.
+                keep the current values).
 
         Returns:
             ``self``, so methods can be chained when loading from multiple sources.
         """
         file = pathlib.Path(file)
+        # TODO: Add a "fail_if_not_found" argument
+
+        # if search_path is set, check the listed directories for the file
+        if search_paths:
+            found = False
+            for directory in search_paths:
+                directory = pathlib.Path(directory)
+                _file = directory / file
+                if _file.is_file():
+                    found = True
+                    break
+
+            if not found:
+                # if file is not found, return without loading anything
+                return self
+                # raise FileNotFoundError(f"No file {file} found in {search_paths}")
+
+            file = _file
+        else:
+            file = pathlib.Path(file)
 
         try:
             fmt = self._file_extensions[file.suffix]
@@ -235,11 +263,5 @@ class WConf:
 
     def load_xdg(self, filename: str) -> WConf:
         """TODO"""
-        raise NotImplementedError()
-        return self
-
-    def load_from_path(self, filename: str, path: typing.Sequence[_PathLike]) -> WConf:
-        """TODO"""
-        # TODO: better name?
         raise NotImplementedError()
         return self


### PR DESCRIPTION
## Description

- Add argument `search_paths` to `load_file()` to optionally provide a list of directories where the file can be located (defaults to using only the current directory).  This was originally planned in a separate function `load_from_path()` but I found that it would be easier to add it to `load_file()`.
- Implement `load_xdg_config` which searches for the file based on XDG base directory specification (defaults to `~/.config` but can be changed via environment variables).  For windows, this is not straight forward, so this is not supported there for now.
- Add argument `fail_if_not_found` to specify what should happen if a requested file is not found (either raise an error or stick with the default values)

## How I Tested
By adding unit tests for everything.