### PR TITLE
feat: Add `strict` argument

### DIFF
--- a/test/data/conf_additional_1.toml
+++ b/test/data/conf_additional_1.toml
@@ -1,0 +1,6 @@
+type = "toml"
+
+[foobar]
+foo = 42
+bar = 13
+additional = "this is not in the schema"

--- a/test/data/conf_additional_2.toml
+++ b/test/data/conf_additional_2.toml
@@ -1,0 +1,10 @@
+type = "toml"
+
+[foobar]
+foo = 42
+bar = 13
+
+# additional section that is not in schema
+[additional]
+bla = 1
+blub = 2

--- a/variconf/wconf.py
+++ b/variconf/wconf.py
@@ -49,17 +49,23 @@ class WConf:
 
     """
 
-    def __init__(self, schema) -> None:
+    def __init__(self, schema, strict: bool = True) -> None:
         """
         Args:
             schema: Configuration structure including all parameters with their default
                 vaules.  This can be a dictionary, a dataclass (in which case type
                 checking is enabled) or any other object that is supported by
                 ``OmegaConf.create``.
+            strict: If true, loading a configuration with parameters that are not listed
+                in schema results in an error.  If false, they will be merged into the
+                configuration.  Note that providing a dataclass as schema implies
+                strict=True.
         """
-        # TODO: add allow_unknown argument
-        # TODO: support schema from file
+        # TODO: support schema from file?
         self.cfg = oc.OmegaConf.create(schema)
+
+        if strict:
+            oc.OmegaConf.set_struct(self.cfg, True)
 
         self._loaders: typing.Dict[str, typing.Tuple[LoaderFunction, bool]] = {
             "json": (self._load_json, False),


### PR DESCRIPTION
## Description
If `strict=True` (default) only parameters that are explicitly listed in the schema are allowed, otherwise an error is thrown (useful to make users aware of typos in the config).
With `strict=False` the old behaviour of silently merging everything, no matter if it was in the schema or not, is enabled.

Implementation-wise this is achieved simply by setting OmegaConf's "struct" flag (`OmegaConf.set_struct`).

## How I tested
By adding unit tests.