### PR TITLE
feat: Add `allow_missing` parameter to get()

### DIFF
--- a/test/test_wconf.py
+++ b/test/test_wconf.py
@@ -46,7 +46,7 @@ def test_defaults(wconf):
 
 
 def test_get(wconf):
-    assert wconf.cfg == wconf.get()
+    assert wconf.cfg == wconf.get(allow_missing=True)
 
 
 def test_load_json(wconf, test_data):
@@ -184,3 +184,15 @@ def test_strict_false(wconf, test_data):
     wconf = WConf(_schema, strict=False)
     wconf.load_file(test_data / "conf_additional_2.toml")
     assert wconf.get().additional == {"bla": 1, "blub": 2}
+
+
+def test_required_parameter(wconf):
+    # "type" is required in the schema ("???") but no config has been provided to set
+    # the value.  Accessing it should result in an error.
+    cfg = wconf.get(allow_missing=True)
+    with pytest.raises(omegaconf.errors.MissingMandatoryValue):
+        cfg.type
+
+    # With allow_missing=False, we should already get an error when calling get()
+    with pytest.raises(omegaconf.errors.MissingMandatoryValue):
+        wconf.get(allow_missing=False)

--- a/variconf/wconf.py
+++ b/variconf/wconf.py
@@ -101,9 +101,26 @@ class WConf:
         """Get list of supported file formats."""
         return list(self._loaders.keys())
 
-    def get(self) -> oc.OmegaConf:
-        """Get the configuration object."""
-        # TODO: Add allow_missing argument
+    def get(self, allow_missing=False) -> oc.OmegaConf:
+        """Get the configuration object.
+
+        Args:
+            allow_missing: If enabled, the config can still contain required parameters
+                which have not been set (accessing them will result in an error).  If
+                disabled (default), get() will check the configuration for missing
+                required values and raise an error instead of returning the config.
+
+        Raises:
+            omegaconfig.errors.MissingMandatoryValue: If ``allow_missing=False`` and the
+                config has one or more required values (marked as missing in the
+                schema), which have not been filled yet.
+        """
+        if not allow_missing:
+            # the easiest way to check the whole config is to convert to a container
+            # with throw_on_missing=True (even though, we're not interested in the
+            # resulting container...).
+            oc.OmegaConf.to_container(self.cfg, throw_on_missing=True)
+
         return self.cfg
 
     def load(self, fp, format: str) -> WConf:


### PR DESCRIPTION
## Description
Normally, the config object may still contain required parameters with missing value and will only raise an error if one tries to access the actual value.  By setting `allow_missing=False` the whole structure will be checked for missing values (resulting in a potential error) before returning it.

## How I tested
By adding unit test.