### PR TITLE
Use custom errors for unknown format/extension

### DIFF
--- a/test/test_wconf.py
+++ b/test/test_wconf.py
@@ -3,7 +3,7 @@ import pathlib
 import pytest
 import omegaconf.errors
 
-from variconf import WConf
+from variconf import WConf, errors
 
 
 _schema = {
@@ -70,6 +70,14 @@ def test_load_toml(wconf, test_data):
     assert wconf.get() == {"foobar": _foobar, "type": "toml"}
 
 
+def test_load_unknown(wconf, test_data):
+    with pytest.raises(errors.UnknownFormatError) as e:
+        with open(test_data / "conf1.toml") as f:
+            wconf.load(f, "bad")
+
+    assert str(e.value) == "bad"
+
+
 def test_load_file_json(wconf, test_data):
     wconf.load_file(test_data / "conf1.json")
     assert wconf.get() == {"foobar": _foobar, "type": "json"}
@@ -83,6 +91,13 @@ def test_load_file_yaml(wconf, test_data):
 def test_load_file_toml(wconf, test_data):
     wconf.load_file(test_data / "conf1.toml")
     assert wconf.get() == {"foobar": _foobar, "type": "toml"}
+
+
+def test_load_file_unknown(wconf, test_data):
+    with pytest.raises(errors.UnknownExtensionError) as e:
+        wconf.load_file(test_data / "conf.ini")
+
+    assert str(e.value) == ".ini"
 
 
 def test_load_dict(wconf):

--- a/variconf/__init__.py
+++ b/variconf/__init__.py
@@ -1,5 +1,6 @@
 from .wconf import WConf
+from .errors import UnknownFormatError, UnknownExtensionError
 
-__all__ = ("WConf",)
+__all__ = ("WConf", "UnknownFormatError", "UnknownExtensionError")
 
 __version__ = "1.0.0alpha1"

--- a/variconf/errors.py
+++ b/variconf/errors.py
@@ -1,0 +1,13 @@
+"""Exceptions specific to the variconf package."""
+
+
+class UnknownFormatError(Exception):
+    """Error indicating that the given file format is unknown."""
+
+    pass
+
+
+class UnknownExtensionError(Exception):
+    """Error indicating that the given file extension is unknown."""
+
+    pass

--- a/variconf/wconf.py
+++ b/variconf/wconf.py
@@ -6,6 +6,8 @@ import os
 
 import omegaconf as oc
 
+from . import errors
+
 
 _PathLike = typing.Union[os.PathLike, str]
 
@@ -137,8 +139,11 @@ class WConf:
         Returns:
             ``self``, so methods can be chained when loading from multiple sources.
         """
-        # TODO: more specific error for unsupported format
-        loader, _ = self._loaders[format]
+        try:
+            loader, _ = self._loaders[format]
+        except KeyError:
+            raise errors.UnknownFormatError(format)
+
         cfg = loader(fp)
         self._merge(cfg)
 
@@ -158,9 +163,13 @@ class WConf:
             ``self``, so methods can be chained when loading from multiple sources.
         """
         file = pathlib.Path(file)
-        fmt = self._file_extensions[file.suffix]
-        _, binary = self._loaders[fmt]
 
+        try:
+            fmt = self._file_extensions[file.suffix]
+        except KeyError:
+            raise errors.UnknownExtensionError(file.suffix)
+
+        _, binary = self._loaders[fmt]
         if binary:
             mode = "rb"
         else:


### PR DESCRIPTION
Use custom errors `UnknownFormatError` and `UnknownExtensionError` if the user provides a format or file extension that is not supported (instead of the generic KeyError that was previously thrown).